### PR TITLE
discountAmount fix

### DIFF
--- a/src/main/java/com/vending/machine/tokyogul/service/impl/BillingServiceImpl.java
+++ b/src/main/java/com/vending/machine/tokyogul/service/impl/BillingServiceImpl.java
@@ -54,7 +54,7 @@ public class BillingServiceImpl implements BillingService {
 		}
 
 		// Calculating total Bill
-		double discountAmount = (calculateDiscount(this.user.getUserHistory()) / 100) * billBeforeDiscount;
+		double discountAmount = (calculateDiscount(this.user.getUserHistory()) / 100.0) * billBeforeDiscount;
 		double billBeforeTax = billBeforeDiscount - discountAmount;
 		double finalBill = billBeforeTax + calculateTaxAmount(billBeforeTax);
 


### PR DESCRIPTION
Dividing by 100.0 instead of dividing by 100 will result in a double value, so discountAmount will be accurate.